### PR TITLE
Fixing management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,7 @@ You can provide your settings in the `settings.py` file of your project. The fol
 DJANGO_VECTOR_DB = {
     "DEFAULT_EMBEDDING_CLASS": "vectordb.embedding_functions.SentenceTransformerEncoder",
     "DEFAULT_EMBEDDING_MODEL": "all-MiniLM-L6-v2",
-    # Can be "cosine" or "l2"
-    "DEFAULT_EMBEDDING_SPACE": "l2"
+    "DEFAULT_EMBEDDING_SPACE": "l2", # Can be "cosine" or "l2"
     "DEFAULT_EMBEDDING_DIMENSION": 384, # Default is 384 for "all-MiniLM-L6-v2"
     "DEFAULT_MAX_N_RESULTS": 10, # Number of results to return from search maximum is default is 10
     "DEFAULT_MIN_SCORE": 0.0, # Minimum score to return from search default is 0.0
@@ -354,7 +353,7 @@ tox
 [python]: https://www.python.org
 [django]: https://www.djangoproject.com
 [numpy]: https://numpy.org
-[quickstart]: tutorial/quickstart.md
+[quickstart]: docs/tutorial/quickstart.md
 [sentence-transformers]: https://www.sbert.net
 [hnswlib]: https://github.com/nmslib/hnswlib
 [drf]: https://www.django-rest-framework.org

--- a/vectordb/management/commands/vectordb_reset.py
+++ b/vectordb/management/commands/vectordb_reset.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         # Check if the user wants to continue
         if user_input.lower() == "yes":
             self.stdout.write(self.style.SUCCESS("Resetting the vector database..."))
-            Vector.objects.all.delete()
+            Vector.objects.all().delete()
             if Vector.objects.index:
                 Vector.objects.index.reset()
         else:

--- a/vectordb/management/commands/vectordb_sync.py
+++ b/vectordb/management/commands/vectordb_sync.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         content_type = ContentType.objects.get_for_model(model)
         vector_instances = Vector.objects.filter(content_type=content_type)
         have_been_deleted_qs = vector_instances.exclude(
-            object_id__in=instances.values_list("pk", flat=True)
+            object_id__in=map(str, instances.values_list("pk", flat=True))
         )
 
         num_to_remove = have_been_deleted_qs.count()

--- a/vectordb/manager.py
+++ b/vectordb/manager.py
@@ -34,7 +34,7 @@ class VectorManager(models.Manager):
 
         logger.info(
             "Loading the weights for the embedding model. This may take a few seconds the first"
-            " time it runs because it downloads the wieghts and caches them."
+            " time it runs because it downloads the weights and caches them."
         )
         start = time.time()
 


### PR DESCRIPTION
Addresses issues on both management commands:

1. `AttributeError: 'function' object has no attribute 'delete'` was encountered on the vectordb_reset management command
2. `psycopg2.errors.UndefinedFunction: operator does not exist: character varying = bigint
LINE 1: ...e_id" = 14 AND NOT ("vectordb_vector"."object_id" IN (SELECT...
                                                             ^
` was encountered when running the vectordb_sync management command. This was due to trying to compare a char field with an int field when looking up objects already embedded that should be excluded.