### PR TITLE
fix as_type float32

### DIFF
--- a/vectordb/embedding_functions.py
+++ b/vectordb/embedding_functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 from django.conf import settings
 
 try:
@@ -49,7 +50,8 @@ class OpenAIEmbeddings:
     def get_embedding(self, text):
         text = text.replace("\n", " ")
         response = openai.Embedding.create(input=[text], model=self.model)
-        return response["data"][0]["embedding"]
+        raw_embedding = response["data"][0]["embedding"]
+        return np.array(raw_embedding, dtype=np.float32)
 
     def __call__(self, text):
         return self.get_embedding(text)


### PR DESCRIPTION
the previous code leads to an error with `embedding=embedding.astype("float32").tobytes()` on line 77 of `utils.py`. This is because the openai embedding response is currently being parsed as a normal list, not a numpy array. This change fixes this.