### PR TITLE
fix case where text is a list

### DIFF
--- a/vectordb/embedding_functions.py
+++ b/vectordb/embedding_functions.py
@@ -54,4 +54,6 @@ class OpenAIEmbeddings:
         return np.array(raw_embedding, dtype=np.float32)
 
     def __call__(self, text):
+        if type(text) is list:
+            return [self.get_embedding(t) for t in text]
         return self.get_embedding(text)


### PR DESCRIPTION
The embedding function `model.objects.embedding_fn` is sometimes called with singular text of type str, but other times called with a list of str `texts`. 

On line 80 of `queryset.py`, we have `query_embeddings = self.model.objects.embedding_fn([text])`, which will break the `get_embedding` function of the `OpenAIEmbeddings` class. You get an error with `text = text.replace("\n", " ")` because text is not a string but instead a list. 

This change fixes this so that `get_embedding` is only called with type string. 