### PR TITLE
update get_embedding function to account for new openai client

### DIFF
--- a/vectordb/embedding_functions.py
+++ b/vectordb/embedding_functions.py
@@ -54,4 +54,6 @@ class OpenAIEmbeddings:
         return np.array(raw_embedding, dtype=np.float32)
 
     def __call__(self, text):
+        if type(text) is list:
+            return [self.get_embedding(t) for t in text]
         return self.get_embedding(text)

--- a/vectordb/embedding_functions.py
+++ b/vectordb/embedding_functions.py
@@ -44,16 +44,18 @@ class OpenAIEmbeddings:
             raise ImportError(
                 "OpenAI API is not installed. Please install openai package. Or run `$ pip install openai`"  # noqa
             )
-        openai.api_key = settings.OPENAI_API_KEY
+        from openai import OpenAI
+
+        self.client = OpenAI(api_key=settings.OPENAI_API_KEY)
         self.model = model_name
 
-    def get_embedding(self, text):
+    def get_embedding(self, text: str) -> np.ndarray:
         text = text.replace("\n", " ")
-        response = openai.Embedding.create(input=[text], model=self.model)
-        raw_embedding = response["data"][0]["embedding"]
+        response = self.client.embeddings.create(input=[text], model=self.model)
+        raw_embedding = response.data[0].embedding
         return np.array(raw_embedding, dtype=np.float32)
 
-    def __call__(self, text):
-        if type(text) is list:
+    def __call__(self, text: str | list[str]) -> np.ndarray:
+        if isinstance(text, list):
             return [self.get_embedding(t) for t in text]
         return self.get_embedding(text)


### PR DESCRIPTION
Because of OpenAI python client 1.0.0 upgrade, we can no longer have openai.Embedding

See similar issue here:
https://github.com/langchain-ai/langchain/issues/12943