### PR TITLE
Update sync_signals.py

### DIFF
--- a/vectordb/sync_signals.py
+++ b/vectordb/sync_signals.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from .models import Vector
 
 
-def sync_vectordb_on_create_update(sender, instance, created, **kwargs):
+def sync_vectordb_on_create_update(sender, instance, created=None, **kwargs):
     """
     Signal to save or update the vectordb when an instance is created or updated.
     """


### PR DESCRIPTION
Added a default value of None for the created argument of the sync_vectordb_on_create_update function to enable its use in other signals such as m2m_changed as in the example below.
``` py
from django.db.models.signals import m2m_changed
from vectordb.sync_signals import sync_vectordb_on_create_update

from .models import SomeModel

m2m_changed.connect(
    sync_vectordb_on_m2m_changed,
    sender=SomeModel.m2m_field.through,
    dispatch_uid="update_vector_index_super_unique_id",
)
```